### PR TITLE
Feature/add domain paramater

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ AddressFinder.configure do |af|
   af.proxy_port = 8080
   af.proxy_user = 'username'
   af.proxy_password = 'password'
+  af.domain = 'http://myserverdomain.com'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ AddressFinder.configure do |af|
   af.proxy_port = 8080
   af.proxy_user = 'username'
   af.proxy_password = 'password'
-  af.domain = 'http://myserverdomain.com'
+  af.domain = 'myserverdomain.com'
 end
 ```
 

--- a/addressfinder.gemspec
+++ b/addressfinder.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec', '~> 3.3'
   gem.add_development_dependency 'guard-rspec', '~> 4.5'
-  gem.add_development_dependency 'bundler', '~> 0'
-  gem.add_development_dependency 'rake', '~> 0'
-  gem.add_development_dependency 'webmock', '~> 0'
+  gem.add_development_dependency 'bundler'
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'webmock'
 end

--- a/lib/addressfinder/cleanse.rb
+++ b/lib/addressfinder/cleanse.rb
@@ -5,13 +5,14 @@ module AddressFinder
 
     attr_reader :result
 
-    def initialize(q:, country: nil, delivered: nil, post_box: nil, rural: nil, region_code: nil, http:)
+    def initialize(q:, country: nil, delivered: nil, post_box: nil, rural: nil, region_code: nil, domain: nil, http:)
       @params = {}
       @params['q'] = q
       @params['delivered'] = delivered if delivered
       @params['post_box'] = post_box if post_box
       @params['rural'] = rural if rural
       @params['region_code'] = region_code if region_code
+      @params['domain'] = domain || config.domain if (domain || config.domain)
       @params['format'] = 'json'
       @params['key'] = config.api_key
       @params['secret'] = config.api_secret

--- a/lib/addressfinder/cleanse.rb
+++ b/lib/addressfinder/cleanse.rb
@@ -30,7 +30,7 @@ module AddressFinder
 
     private
 
-    attr_reader :request_uri, :params, :result, :country, :http
+    attr_reader :request_uri, :params, :country, :http
     attr_accessor :response_body, :response_status
     attr_writer :result
 

--- a/lib/addressfinder/configuration.rb
+++ b/lib/addressfinder/configuration.rb
@@ -10,6 +10,7 @@ module AddressFinder
     attr_accessor :proxy_password
     attr_accessor :timeout
     attr_accessor :default_country
+    attr_accessor :domain
 
     def initialize
       self.hostname = 'api.addressfinder.io'

--- a/lib/addressfinder/location_info.rb
+++ b/lib/addressfinder/location_info.rb
@@ -10,6 +10,7 @@ module AddressFinder
       @country = params.delete(:country) || config.default_country
 
       @params = params
+      @params['domain'] = params['domain'] || config.domain if (params['domain'] || config.domain)
       @params['key'] = config.api_key
       @params['secret'] = config.api_secret
     end

--- a/lib/addressfinder/location_search.rb
+++ b/lib/addressfinder/location_search.rb
@@ -10,6 +10,7 @@ module AddressFinder
       @country = params.delete(:country) || config.default_country
 
       @params = params
+      @params['domain'] = params['domain'] || config.domain if (params['domain'] || config.domain)
       @params['key'] = config.api_key
       @params['secret'] = config.api_secret
     end

--- a/spec/lib/addressfinder/cleanse_spec.rb
+++ b/spec/lib/addressfinder/cleanse_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe AddressFinder::Cleanse do
         let(:args){ {q: '123', http: http} }
 
         it 'should use the config domain if set' do
-          AddressFinder.configuration.domain = 'http://testdomain.com'
-          expect(request_uri).to eq('/api/nz/address/cleanse?q=123&domain=http://testdomain.com&format=json&key=XXX&secret=YYY')
+          AddressFinder.configuration.domain = 'anotherdomain.com'
+          expect(request_uri).to eq('/api/nz/address/cleanse?q=123&domain=anotherdomain.com&format=json&key=XXX&secret=YYY')
           AddressFinder.configuration.domain = nil # set back to nil after
         end
       end

--- a/spec/lib/addressfinder/cleanse_spec.rb
+++ b/spec/lib/addressfinder/cleanse_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe AddressFinder::Cleanse do
 
       it { expect(request_uri).to eq('/api/au/address/cleanse?q=186%20willis%20st&format=json&key=XXX&secret=YYY') }
     end
+
+    context 'with a domain given' do
+      let(:args){ {q: '123', domain: 'testdomain.com', http: http} }
+
+      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=123&domain=testdomain.com&format=json&key=XXX&secret=YYY') }
+
+      context 'given in the AF configuration' do
+
+        let(:args){ {q: '123', http: http} }
+
+        it 'should use the config domain if set' do
+          AddressFinder.configuration.domain = 'http://testdomain.com'
+          expect(request_uri).to eq('/api/nz/address/cleanse?q=123&domain=http://testdomain.com&format=json&key=XXX&secret=YYY')
+          AddressFinder.configuration.domain = nil # set back to nil after
+        end
+      end
+    end
   end
 
   describe '#build_result' do

--- a/spec/lib/addressfinder/location_info_spec.rb
+++ b/spec/lib/addressfinder/location_info_spec.rb
@@ -26,6 +26,23 @@ RSpec.describe AddressFinder::LocationInfo do
 
       it { expect(request_uri).to eq('/api/au/location/info.json?pxid=123&key=XXX&secret=YYY') }
     end
+
+    context 'with a domain given' do
+      let(:args){ {pxid: '123', domain: 'testdomain.com'} }
+
+      it { expect(request_uri).to eq('/api/au/location/info.json?pxid=123&domain=testdomain.com&key=XXX&secret=YYY') }
+
+      context 'given in the AF configuration' do
+
+        let(:args){ {pxid: '123'} }
+
+        it 'should use the config domain if set' do
+          AddressFinder.configuration.domain = 'http://testdomain.com'
+          expect(request_uri).to eq('/api/au/location/info.json?pxid=123&domain=http://testdomain.com&key=XXX&secret=YYY')
+          AddressFinder.configuration.domain = nil # set back to nil after
+        end
+      end
+    end
   end
 
   describe '#build_result' do

--- a/spec/lib/addressfinder/location_info_spec.rb
+++ b/spec/lib/addressfinder/location_info_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe AddressFinder::LocationInfo do
         let(:args){ {pxid: '123'} }
 
         it 'should use the config domain if set' do
-          AddressFinder.configuration.domain = 'http://testdomain.com'
-          expect(request_uri).to eq('/api/au/location/info.json?pxid=123&domain=http://testdomain.com&key=XXX&secret=YYY')
+          AddressFinder.configuration.domain = 'anotherdomain.com'
+          expect(request_uri).to eq('/api/au/location/info.json?pxid=123&domain=anotherdomain.com&key=XXX&secret=YYY')
           AddressFinder.configuration.domain = nil # set back to nil after
         end
       end

--- a/spec/lib/addressfinder/location_search_spec.rb
+++ b/spec/lib/addressfinder/location_search_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe AddressFinder::LocationSearch do
         let(:args){ {q: '123'} }
 
         it 'should use the config domain if set' do
-          AddressFinder.configuration.domain = 'http://testdomain.com'
-          expect(request_uri).to eq('/api/nz/location.json?q=123&domain=http://testdomain.com&key=XXX&secret=YYY')
+          AddressFinder.configuration.domain = 'anotherdomain.com'
+          expect(request_uri).to eq('/api/nz/location.json?q=123&domain=anotherdomain.com&key=XXX&secret=YYY')
           AddressFinder.configuration.domain = nil # set back to nil after
         end
       end

--- a/spec/lib/addressfinder/location_search_spec.rb
+++ b/spec/lib/addressfinder/location_search_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe AddressFinder::LocationSearch do
 
       it { expect(request_uri).to eq('/api/au/location.json?q=willis%20st&key=XXX&secret=YYY') }
     end
+
+    context 'with a domain given' do
+      let(:args){ {q: '123', domain: 'testdomain.com'} }
+
+      it { expect(request_uri).to eq('/api/nz/location.json?q=123&domain=testdomain.com&key=XXX&secret=YYY') }
+
+      context 'given in the AF configuration' do
+
+        let(:args){ {q: '123'} }
+
+        it 'should use the config domain if set' do
+          AddressFinder.configuration.domain = 'http://testdomain.com'
+          expect(request_uri).to eq('/api/nz/location.json?q=123&domain=http://testdomain.com&key=XXX&secret=YYY')
+          AddressFinder.configuration.domain = nil # set back to nil after
+        end
+      end
+    end
   end
 
   describe '#build_result' do


### PR DESCRIPTION
Add support for the new `domain` parameter.

Support has been added to:
- Cleanse API
- Location Info API
- Location Search API

Specs have also been included which show behaviour when a domain is given in the `AddressFinder.configuration`settings.