### PR TITLE
Feature/add http config to bulk operation

### DIFF
--- a/addressfinder.gemspec
+++ b/addressfinder.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec', '~> 3.3'
   gem.add_development_dependency 'guard-rspec', '~> 4.5'
-  gem.add_development_dependency 'bundler', '~> 10.0.6'
+  gem.add_development_dependency 'bundler', '>= 1.6.5'
   gem.add_development_dependency 'rake', '~> 10.4.2'
   gem.add_development_dependency 'webmock', '~> 1.21.0'
 end

--- a/addressfinder.gemspec
+++ b/addressfinder.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec', '~> 3.3'
   gem.add_development_dependency 'guard-rspec', '~> 4.5'
-  gem.add_development_dependency 'bundler', '~> 0'
-  gem.add_development_dependency 'rake', '~> 0'
-  gem.add_development_dependency 'webmock', '~> 0'
+  gem.add_development_dependency 'bundler', '~> 10.0.6'
+  gem.add_development_dependency 'rake', '~> 10.4.2'
+  gem.add_development_dependency 'webmock', '~> 1.21.0'
 end

--- a/lib/addressfinder.rb
+++ b/lib/addressfinder.rb
@@ -37,8 +37,7 @@ module AddressFinder
     end
 
     def bulk(&block)
-      # TODO include parameter http: configure_http
-      AddressFinder::Bulk.new(&block).perform
+      AddressFinder::Bulk.new(http_config: configure_http, &block).perform
     end
 
     private

--- a/lib/addressfinder/bulk.rb
+++ b/lib/addressfinder/bulk.rb
@@ -21,7 +21,7 @@ module AddressFinder
       end
 
       def cleanse(args={})
-        AddressFinder::Cleanse.new(args.merge(http: http)).perform
+        AddressFinder::Cleanse.new(args.merge(http: http)).perform.result
       end
 
       private

--- a/lib/addressfinder/bulk.rb
+++ b/lib/addressfinder/bulk.rb
@@ -1,24 +1,19 @@
 module AddressFinder
   class Bulk
-    def initialize(&block)
+    def initialize(http_config:,  &block)
       @block = block
+      @http_config = http_config
     end
 
     def perform
-      Net::HTTP.start(config.hostname, config.port, use_ssl: true,
-                                                    open_timeout: config.timeout,
-                                                    read_timeout: config.timeout) do |http|
+      http_config.start do |http|
         block.call ClientProxy.new(http: http)
       end
     end
 
     private
 
-    attr_reader :block
-
-    def config
-      @_config ||= AddressFinder.configuration
-    end
+    attr_reader :block, :http_config
 
     class ClientProxy
       def initialize(http:)


### PR DESCRIPTION
Pass the `http_config` settings from `AddressFinder.rb` to the bulk operation class.

This follows the approach we have used for other operations.
