### PR TITLE
Encode params for cleanse API the same way we do for other APIs

### DIFF
--- a/lib/addressfinder.rb
+++ b/lib/addressfinder.rb
@@ -9,6 +9,7 @@ require 'addressfinder/address_info'
 require 'addressfinder/address_search'
 require 'addressfinder/bulk'
 require 'addressfinder/errors'
+require 'addressfinder/util'
 
 module AddressFinder
   class << self

--- a/lib/addressfinder/address_info.rb
+++ b/lib/addressfinder/address_info.rb
@@ -33,8 +33,7 @@ module AddressFinder
     end
 
     def encoded_params
-      query = params.map{|k,v| "#{k}=#{v}"}.join('&')
-      URI::encode(query)
+      Util.encode_and_join_params(params)
     end
 
     def execute_request

--- a/lib/addressfinder/address_search.rb
+++ b/lib/addressfinder/address_search.rb
@@ -33,8 +33,7 @@ module AddressFinder
     end
 
     def encoded_params
-      query = params.map{|k,v| "#{k}=#{v}"}.join('&')
-      URI::encode(query)
+      Util.encode_and_join_params(params)
     end
 
     def execute_request

--- a/lib/addressfinder/cleanse.rb
+++ b/lib/addressfinder/cleanse.rb
@@ -60,8 +60,7 @@ module AddressFinder
     end
 
     def encoded_params
-      query_params = params.map{|k,v| "#{k}=#{v}"}.join('&')
-      URI::encode(query_params)
+      Util.encode_and_join_params(params)
     end
 
     def response_hash

--- a/lib/addressfinder/cleanse.rb
+++ b/lib/addressfinder/cleanse.rb
@@ -60,11 +60,8 @@ module AddressFinder
     end
 
     def encoded_params
-      query_params = params.map do |k,v|
-        "#{k}=#{ERB::Util.url_encode(v)}"
-      end
-
-      query_params.join('&')
+      query_params = params.map{|k,v| "#{k}=#{v}"}.join('&')
+      URI::encode(query_params)
     end
 
     def response_hash

--- a/lib/addressfinder/location_info.rb
+++ b/lib/addressfinder/location_info.rb
@@ -34,8 +34,7 @@ module AddressFinder
     end
 
     def encoded_params
-      query = params.map{|k,v| "#{k}=#{v}"}.join('&')
-      URI::encode(query)
+      Util.encode_and_join_params(params)
     end
 
     def execute_request

--- a/lib/addressfinder/location_search.rb
+++ b/lib/addressfinder/location_search.rb
@@ -34,8 +34,7 @@ module AddressFinder
     end
 
     def encoded_params
-      query = params.map{|k,v| "#{k}=#{v}"}.join('&')
-      URI::encode(query)
+      Util.encode_and_join_params(params)
     end
 
     def execute_request

--- a/lib/addressfinder/util.rb
+++ b/lib/addressfinder/util.rb
@@ -1,0 +1,12 @@
+module AddressFinder
+  class Util
+
+    def self.encode(v)
+      CGI::escape(v.to_s)
+    end
+
+    def self.encode_and_join_params(params)
+      params.map{ |k,v| "#{k}=#{encode(v)}" }.join('&')
+    end
+  end
+end

--- a/spec/lib/addressfinder/address_search_spec.rb
+++ b/spec/lib/addressfinder/address_search_spec.rb
@@ -18,31 +18,31 @@ RSpec.describe AddressFinder::AddressSearch do
     context 'with minimal arguments' do
       let(:args){ {q: '186 willis'} }
 
-      it { expect(request_uri).to eq('/api/nz/address.json?q=186%20willis&key=XXX&secret=YYY') }
+      it { expect(request_uri).to eq('/api/nz/address.json?q=186+willis&key=XXX&secret=YYY') }
     end
 
     context 'with more arguments' do
       let(:args){ {q: '186 willis st', delivered: 1, max: 10} }
 
-      it { expect(request_uri).to eq('/api/nz/address.json?q=186%20willis%20st&delivered=1&max=10&key=XXX&secret=YYY') }
+      it { expect(request_uri).to eq('/api/nz/address.json?q=186+willis+st&delivered=1&max=10&key=XXX&secret=YYY') }
     end
 
     context 'with a country override' do
       let(:args){ {q: '186 willis st', country: 'au'} }
 
-      it { expect(request_uri).to eq('/api/au/address.json?q=186%20willis%20st&key=XXX&secret=YYY') }
+      it { expect(request_uri).to eq('/api/au/address.json?q=186+willis+st&key=XXX&secret=YYY') }
     end
 
     context 'with a key override' do
       let(:args){ {q: '186 willis st', key: 'AAA'} }
 
-      it { expect(request_uri).to eq('/api/nz/address.json?q=186%20willis%20st&key=AAA&secret=YYY') }
+      it { expect(request_uri).to eq('/api/nz/address.json?q=186+willis+st&key=AAA&secret=YYY') }
     end
 
     context 'with a secret override' do
       let(:args){ {q: '186 willis st', secret: 'BBB'} }
 
-      it { expect(request_uri).to eq('/api/nz/address.json?q=186%20willis%20st&secret=BBB&key=XXX') }
+      it { expect(request_uri).to eq('/api/nz/address.json?q=186+willis+st&secret=BBB&key=XXX') }
     end
   end
 

--- a/spec/lib/addressfinder/cleanse_spec.rb
+++ b/spec/lib/addressfinder/cleanse_spec.rb
@@ -18,31 +18,31 @@ RSpec.describe AddressFinder::Cleanse do
     context 'with minimal arguments' do
       let(:args){ {q: '186 willis st', http: http} }
 
-      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=186%20willis%20st&format=json&key=XXX&secret=YYY') }
+      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=186+willis+st&format=json&key=XXX&secret=YYY') }
     end
 
     context 'with more arguments' do
       let(:args){ {q: '186 willis st', delivered: true, region_code: 'A', http: http} }
 
-      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=186%20willis%20st&delivered=true&region_code=A&format=json&key=XXX&secret=YYY') }
+      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=186+willis+st&delivered=true&region_code=A&format=json&key=XXX&secret=YYY') }
     end
 
     context 'with a country override' do
       let(:args){ {q: '186 willis st', country: 'au', http: http} }
 
-      it { expect(request_uri).to eq('/api/au/address/cleanse?q=186%20willis%20st&format=json&key=XXX&secret=YYY') }
+      it { expect(request_uri).to eq('/api/au/address/cleanse?q=186+willis+st&format=json&key=XXX&secret=YYY') }
     end
 
     context 'with a key override' do
       let(:args){ {q: '186 willis st', key: 'AAA', http: http} }
 
-      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=186%20willis%20st&format=json&key=AAA&secret=YYY') }
+      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=186+willis+st&format=json&key=AAA&secret=YYY') }
     end
 
     context 'with a secret override' do
       let(:args){ {q: '186 willis st', secret: 'BBB', http: http} }
 
-      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=186%20willis%20st&format=json&key=XXX&secret=BBB') }
+      it { expect(request_uri).to eq('/api/nz/address/cleanse?q=186+willis+st&format=json&key=XXX&secret=BBB') }
     end
 
     context 'with a domain given' do
@@ -89,34 +89,6 @@ RSpec.describe AddressFinder::Cleanse do
       let(:status){ '200' }
 
       it { expect(result).to eq(nil) }
-    end
-  end
-
-  describe '#encoded_params' do
-    subject(:encoded_params){ AddressFinder::Cleanse.new(q: q, http: nil).send(:encoded_params) }
-
-    context 'with a question mark value' do
-      let(:q){ '?' }
-
-      it { expect(encoded_params).to eq('q=%3F&format=json&key=XXX&secret=YYY') }
-    end
-
-    context 'with a normal address value' do
-      let(:q){ '12 high' }
-
-      it { expect(encoded_params).to eq('q=12%20high&format=json&key=XXX&secret=YYY') }
-    end
-
-    context 'with a blank value' do
-      let(:q){ '' }
-
-      it { expect(encoded_params).to eq('q=&format=json&key=XXX&secret=YYY') }
-    end
-
-    context 'with a nil value' do
-      let(:q){ nil }
-
-      it { expect(encoded_params).to eq('q=&format=json&key=XXX&secret=YYY') }
     end
   end
 end

--- a/spec/lib/addressfinder/cleanse_spec.rb
+++ b/spec/lib/addressfinder/cleanse_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe AddressFinder::Cleanse do
     context 'with a question mark value' do
       let(:q){ '?' }
 
-      it { expect(encoded_params).to eq('q=%3F&format=json&key=XXX&secret=YYY') }
+      it { expect(encoded_params).to eq('q=?&format=json&key=XXX&secret=YYY') }
     end
 
     context 'with a normal address value' do

--- a/spec/lib/addressfinder/cleanse_spec.rb
+++ b/spec/lib/addressfinder/cleanse_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe AddressFinder::Cleanse do
     context 'with a question mark value' do
       let(:q){ '?' }
 
-      it { expect(encoded_params).to eq('q=?&format=json&key=XXX&secret=YYY') }
+      it { expect(encoded_params).to eq('q=%3F&format=json&key=XXX&secret=YYY') }
     end
 
     context 'with a normal address value' do

--- a/spec/lib/addressfinder/location_search_spec.rb
+++ b/spec/lib/addressfinder/location_search_spec.rb
@@ -24,25 +24,25 @@ RSpec.describe AddressFinder::LocationSearch do
     context 'with more arguments' do
       let(:args){ {q: 'willis st', street: 1, max: 10} }
 
-      it { expect(request_uri).to eq('/api/nz/location.json?q=willis%20st&street=1&max=10&key=XXX&secret=YYY') }
+      it { expect(request_uri).to eq('/api/nz/location.json?q=willis+st&street=1&max=10&key=XXX&secret=YYY') }
     end
 
     context 'with a country override' do
       let(:args){ {q: 'willis st', country: 'au'} }
 
-      it { expect(request_uri).to eq('/api/au/location.json?q=willis%20st&key=XXX&secret=YYY') }
+      it { expect(request_uri).to eq('/api/au/location.json?q=willis+st&key=XXX&secret=YYY') }
     end
 
     context 'with a key override' do
       let(:args){ {q: 'willis st', key: 'AAA'} }
 
-      it { expect(request_uri).to eq('/api/nz/location.json?q=willis%20st&key=AAA&secret=YYY') }
+      it { expect(request_uri).to eq('/api/nz/location.json?q=willis+st&key=AAA&secret=YYY') }
     end
 
     context 'with a secret override' do
       let(:args){ {q: 'willis st', secret: 'BBB'} }
 
-      it { expect(request_uri).to eq('/api/nz/location.json?q=willis%20st&secret=BBB&key=XXX') }
+      it { expect(request_uri).to eq('/api/nz/location.json?q=willis+st&secret=BBB&key=XXX') }
     end
 
     context 'with a domain given' do

--- a/spec/lib/addressfinder/util_spec.rb
+++ b/spec/lib/addressfinder/util_spec.rb
@@ -1,0 +1,37 @@
+require 'addressfinder/util'
+
+RSpec.describe AddressFinder::Util do
+  describe '.encode_and_join_params' do
+    subject { AddressFinder::Util.encode_and_join_params(params) }
+
+    context 'with a question mark value' do
+      let(:params){ {q:'?',format:'json',key:'XXX',secret:'YYY'} }
+
+      it { is_expected.to eq('q=%3F&format=json&key=XXX&secret=YYY') }
+    end
+
+    context 'with an ampersand value' do
+      let(:params){ {q:'&',format:'json',key:'XXX',secret:'YYY'} }
+
+      it { is_expected.to eq('q=%26&format=json&key=XXX&secret=YYY') }
+    end
+
+    context 'with a normal address value' do
+      let(:params){ {q:'12 high',format:'json',key:'XXX',secret:'YYY'} }
+
+      it { is_expected.to eq('q=12+high&format=json&key=XXX&secret=YYY') }
+    end
+
+    context 'with a blank value' do
+      let(:params){ {q:'',format:'json',key:'XXX',secret:'YYY'} }
+
+      it { is_expected.to eq('q=&format=json&key=XXX&secret=YYY') }
+    end
+
+    context 'with a nil value' do
+      let(:params){ {q:nil,format:'json',key:'XXX',secret:'YYY'} }
+
+      it { is_expected.to eq('q=&format=json&key=XXX&secret=YYY') }
+    end
+  end
+end


### PR DESCRIPTION
Code change for issue #10 